### PR TITLE
Implement Oracle models and CRUD

### DIFF
--- a/app/api/v1/customer.py
+++ b/app/api/v1/customer.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from app.schemas.customer import CustomerCreate, CustomerOut
 from app.crud import customer as crud_customer
-from app.api.deps import get_db
+from app.database import get_db
 
 router = APIRouter(prefix="/customers", tags=["customers"])
 

--- a/app/api/v1/flight.py
+++ b/app/api/v1/flight.py
@@ -1,26 +1,21 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Depends
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from app.database import get_db
+from app.crud import flight as crud_flight
+from app.schemas.flight import FlightOut
 
 router = APIRouter(prefix="/flights", tags=["flights"])
 
-@router.get("/search")
+@router.get("/search", response_model=list[FlightOut])
 def search_flights(
     origin: str = Query(..., alias="from"),
     dest: str = Query(..., alias="to"),
     depDate: str = Query(...),
-    retDate: str | None = Query(None),
+    db: Session = Depends(get_db),
 ):
-    """Demo search endpoint returning static data."""
-    return [
-        {
-            "flightId": 1,
-            "airline": "Sample Air",
-            "flightNo": "SA100",
-            "departureTime": f"{depDate}T08:00:00",
-            "arrivalTime": f"{depDate}T10:30:00",
-            "duration": "2h30m",
-            "seatClass": "Economy",
-            "price": 120000,
-            "remaining": 20,
-        }
-    ]
+    """Search flights from the database."""
+    dep_date = datetime.fromisoformat(depDate).date()
+    return crud_flight.search(db, origin, dest, dep_date)
 

--- a/app/api/v1/seat.py
+++ b/app/api/v1/seat.py
@@ -1,20 +1,28 @@
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.crud import seat as crud_seat
+from app.schemas.flight import SeatOut
 
 router = APIRouter(prefix="/admin/flights", tags=["seats"])
 
-@router.get("/{flight_id}/seats")
-def list_seats(flight_id: int = Path(...)):
-    """Return demo seat list for the given flight."""
-    return [
-        {"id": 1, "class": "Economy", "price": 120000, "total": 100},
-        {"id": 2, "class": "Business", "price": 500000, "total": 20},
-    ]
-
-@router.delete("/{flight_id}/seats/{seat_id}", status_code=204)
-def delete_seat(
-    flight_id: int = Path(...),
-    seat_id: int = Path(...),
+@router.get("/{flight_no}/{dep_dt}/seats", response_model=list[SeatOut])
+def list_seats(
+    flight_no: str = Path(...),
+    dep_dt: str = Path(...),
+    db: Session = Depends(get_db),
 ):
-    """Demo deletion endpoint."""
-    return
+    """List seat classes for a flight."""
+    return crud_seat.list_by_flight(db, flight_no, dep_dt)
+
+@router.delete("/{flight_no}/{dep_dt}/seats/{seat_class}", status_code=204)
+def delete_seat(
+    flight_no: str = Path(...),
+    dep_dt: str = Path(...),
+    seat_class: str = Path(...),
+    db: Session = Depends(get_db),
+):
+    """Remove a seat class from a flight."""
+    crud_seat.delete(db, flight_no, dep_dt, seat_class)
 

--- a/app/crud/flight.py
+++ b/app/crud/flight.py
@@ -1,0 +1,25 @@
+from datetime import date, datetime
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.flight import Airplain
+
+
+def list(db: Session, departure_airport: str | None = None):
+    stmt = select(Airplain)
+    if departure_airport:
+        stmt = stmt.where(Airplain.departureAirport == departure_airport)
+    return db.scalars(stmt).all()
+
+
+def search(db: Session, departure: str, arrival: str, dep_date: date):
+    stmt = (
+        select(Airplain)
+        .where(
+            Airplain.departureAirport == departure,
+            Airplain.arrivalAirport == arrival,
+            func.trunc(Airplain.departureDateTime) == dep_date,
+        )
+        .options(selectinload(Airplain.seats))
+    )
+    return db.scalars(stmt).all()

--- a/app/crud/reservation.py
+++ b/app/crud/reservation.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from sqlalchemy.orm import Session
+from app.models.reservation import Reserve
+from app.schemas.reservation import ReservationCreate
+
+
+def create(db: Session, obj_in: ReservationCreate) -> Reserve:
+    db_obj = Reserve(**obj_in.dict(), reserveDateTime=obj_in.departureDateTime)
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get(
+    db: Session,
+    flight_no: str,
+    dep_dt: str,
+    seat_class: str,
+    cno: int,
+) -> Reserve | None:
+    dep_dt_parsed = datetime.fromisoformat(dep_dt)
+    return db.get(
+        Reserve,
+        {
+            "flightNo": flight_no,
+            "departureDateTime": dep_dt_parsed,
+            "seatClass": seat_class,
+            "cno": cno,
+        },
+    )

--- a/app/crud/seat.py
+++ b/app/crud/seat.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from sqlalchemy import update, select
+from sqlalchemy.orm import Session
+
+from app.models.flight import Seats
+
+
+def adjust_price(db: Session, flight_no: str, dep_dt: str, percentage: float) -> int:
+    dep_dt_parsed = datetime.fromisoformat(dep_dt)
+    stmt = (
+        update(Seats)
+        .where(Seats.flightNo == flight_no, Seats.departureDateTime == dep_dt_parsed)
+        .values(price=Seats.price * (1 + percentage / 100))
+    )
+    result = db.execute(stmt)
+    db.commit()
+    return result.rowcount
+
+
+def list_by_flight(db: Session, flight_no: str, dep_dt: str) -> list[Seats]:
+    dep_dt_parsed = datetime.fromisoformat(dep_dt)
+    stmt = select(Seats).where(
+        Seats.flightNo == flight_no,
+        Seats.departureDateTime == dep_dt_parsed,
+    )
+    return db.scalars(stmt).all()
+
+
+def delete(db: Session, flight_no: str, dep_dt: str, seat_class: str) -> int:
+    dep_dt_parsed = datetime.fromisoformat(dep_dt)
+    obj = db.get(Seats, {"flightNo": flight_no, "departureDateTime": dep_dt_parsed, "seatClass": seat_class})
+    if obj:
+        db.delete(obj)
+        db.commit()
+        return 1
+    return 0

--- a/app/models/flight.py
+++ b/app/models/flight.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import String, DateTime, Integer, Numeric, ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from app.database import Base
+
+class Airplain(Base):
+    __tablename__ = "Airplain"
+
+    flightNo: Mapped[str] = mapped_column(String(20), primary_key=True)
+    departureDateTime: Mapped[datetime] = mapped_column(DateTime, primary_key=True)
+    airline: Mapped[str] = mapped_column(String(50))
+    departureAirport: Mapped[str] = mapped_column(String(50))
+    arrivalDateTime: Mapped[datetime] = mapped_column(DateTime)
+    arrivalAirport: Mapped[str] = mapped_column(String(50))
+
+    seats: Mapped[list["Seats"]] = relationship("Seats", back_populates="airplain")
+
+class Seats(Base):
+    __tablename__ = "Seats"
+
+    flightNo: Mapped[str] = mapped_column(String(20), primary_key=True)
+    departureDateTime: Mapped[datetime] = mapped_column(DateTime, primary_key=True)
+    seatClass: Mapped[str] = mapped_column(String(20), primary_key=True)
+    price: Mapped[float] = mapped_column(Numeric)
+    no_of_seats: Mapped[int] = mapped_column(Integer)
+
+    __table_args__ = (
+        ForeignKeyConstraint([
+            "flightNo",
+            "departureDateTime",
+        ], [
+            "Airplain.flightNo",
+            "Airplain.departureDateTime",
+        ]),
+    )
+
+    airplain: Mapped[Airplain] = relationship("Airplain", back_populates="seats")

--- a/app/models/reservation.py
+++ b/app/models/reservation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import String, DateTime, Integer, Numeric, ForeignKey, ForeignKeyConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from app.database import Base
+
+class Reserve(Base):
+    __tablename__ = "Reserve"
+
+    flightNo: Mapped[str] = mapped_column(String(20), primary_key=True)
+    departureDateTime: Mapped[datetime] = mapped_column(DateTime, primary_key=True)
+    seatClass: Mapped[str] = mapped_column(String(20), primary_key=True)
+    cno: Mapped[int] = mapped_column(ForeignKey("Customer.cno"), primary_key=True)
+    payment: Mapped[float] = mapped_column(Numeric)
+    reserveDateTime: Mapped[datetime] = mapped_column(DateTime)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["flightNo", "departureDateTime", "seatClass"],
+            ["Seats.flightNo", "Seats.departureDateTime", "Seats.seatClass"],
+        ),
+    )
+
+    customer: Mapped["Customer"] = relationship("Customer")
+
+class Cancel(Base):
+    __tablename__ = "Cancel"
+
+    flightNo: Mapped[str] = mapped_column(String(20), primary_key=True)
+    departureDateTime: Mapped[datetime] = mapped_column(DateTime, primary_key=True)
+    seatClass: Mapped[str] = mapped_column(String(20), primary_key=True)
+    cno: Mapped[int] = mapped_column(ForeignKey("Customer.cno"), primary_key=True)
+    refund: Mapped[float] = mapped_column(Numeric)
+    cancelDateTime: Mapped[datetime] = mapped_column(DateTime)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["flightNo", "departureDateTime", "seatClass"],
+            ["Seats.flightNo", "Seats.departureDateTime", "Seats.seatClass"],
+        ),
+    )
+
+    customer: Mapped["Customer"] = relationship("Customer")

--- a/app/schemas/flight.py
+++ b/app/schemas/flight.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import List
+
+class SeatOut(BaseModel):
+    seatClass: str
+    price: float
+    no_of_seats: int
+
+    class Config:
+        orm_mode = True
+
+class FlightOut(BaseModel):
+    airline: str
+    flightNo: str
+    departureDateTime: datetime
+    departureAirport: str
+    arrivalDateTime: datetime
+    arrivalAirport: str
+    seats: List[SeatOut] = []
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/reservation.py
+++ b/app/schemas/reservation.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+class ReservationCreate(BaseModel):
+    flightNo: str
+    departureDateTime: datetime
+    seatClass: str
+    cno: int
+    payment: float
+
+class ReservationOut(BaseModel):
+    flightNo: str
+    departureDateTime: datetime
+    seatClass: str
+    cno: int
+    payment: float
+    reserveDateTime: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add `flight` and `reservation` SQLAlchemy models
- implement flight search and admin seat price adjustments
- expose new CRUD helpers for flights, seats, and reservations
- define response schemas for flights
- use `get_db` from `database` in customer router
- connect reservation and seat APIs to Oracle database

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853ee5d1864832e93229c0f8bd5df01