### PR TITLE
Fix reservation API with unique id

### DIFF
--- a/app/api/v1/reservation.py
+++ b/app/api/v1/reservation.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter, Path, status, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.core.auth_deps import get_current_user
 from app.crud import reservation as crud_reservation
+from app.models.customer import Customer
 from app.schemas.reservation import ReservationCreate, ReservationOut
 
 router = APIRouter(prefix="/reservations", tags=["reservations"])
@@ -14,33 +16,31 @@ def create_reservation(payload: ReservationCreate, db: Session = Depends(get_db)
     return crud_reservation.create(db, payload)
 
 
-@router.get("/{flight_no}/{dep_dt}/{seat_class}/{cno}", response_model=ReservationOut)
+@router.get("/{reservation_id}", response_model=ReservationOut)
 def read_reservation(
-    flight_no: str = Path(...),
-    dep_dt: str = Path(...),
-    seat_class: str = Path(...),
-    cno: int = Path(...),
+    reservation_id: int = Path(...),
     db: Session = Depends(get_db),
 ):
-    """Fetch a reservation by composite key."""
-    db_obj = crud_reservation.get(db, flight_no, dep_dt, seat_class, cno)
+    """Fetch a reservation by id."""
+    db_obj = crud_reservation.get(db, reservation_id)
     if not db_obj:
         raise HTTPException(status_code=404, detail="Reservation not found")
     return db_obj
 
 
-@router.delete("/{flight_no}/{dep_dt}/{seat_class}/{cno}", status_code=status.HTTP_204_NO_CONTENT)
-def cancel_reservation(
-    flight_no: str = Path(...),
-    dep_dt: str = Path(...),
-    seat_class: str = Path(...),
-    cno: int = Path(...),
+@router.delete("/{reservation_id}", response_model=ReservationOut)
+def delete_reservation(
+    reservation_id: int,
     db: Session = Depends(get_db),
+    current_user: Customer = Depends(get_current_user),
 ):
     """Cancel (delete) a reservation."""
-    obj = crud_reservation.get(db, flight_no, dep_dt, seat_class, cno)
-    if obj:
-        db.delete(obj)
-        db.commit()
-    return
+    db_reservation = crud_reservation.get(db, reservation_id)
+    if db_reservation is None:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    if db_reservation.cno != current_user.cno:
+        raise HTTPException(status_code=403, detail="Not authorized to delete this reservation")
+
+    deleted = crud_reservation.remove(db, reservation_id)
+    return deleted
 

--- a/app/api/v1/user_profile.py
+++ b/app/api/v1/user_profile.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
 from app.core.auth_deps import get_current_user
+from app.database import get_db
+from app.crud import reservation as crud_reservation
 from app.models.customer import Customer
+from app.schemas.reservation import ReservationOut
 
 router = APIRouter(prefix="/profile", tags=["user-profile"])
 
@@ -12,4 +17,13 @@ def read_profile(current_user: Customer = Depends(get_current_user)):
         "name": current_user.name,
         "email": current_user.email,
     }
+
+
+@router.get("/me/reservations", response_model=list[ReservationOut])
+def read_my_reservations(
+    current_user: Customer = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return reservations for the logged in user."""
+    return crud_reservation.get_by_customer(db, cno=current_user.cno)
 

--- a/app/crud/reservation.py
+++ b/app/crud/reservation.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+from sqlalchemy import select
 from sqlalchemy.orm import Session
+
 from app.models.reservation import Reserve
 from app.schemas.reservation import ReservationCreate
 
@@ -12,20 +14,17 @@ def create(db: Session, obj_in: ReservationCreate) -> Reserve:
     return db_obj
 
 
-def get(
-    db: Session,
-    flight_no: str,
-    dep_dt: str,
-    seat_class: str,
-    cno: int,
-) -> Reserve | None:
-    dep_dt_parsed = datetime.fromisoformat(dep_dt)
-    return db.get(
-        Reserve,
-        {
-            "flightNo": flight_no,
-            "departureDateTime": dep_dt_parsed,
-            "seatClass": seat_class,
-            "cno": cno,
-        },
-    )
+def get(db: Session, reservation_id: int) -> Reserve | None:
+    return db.get(Reserve, reservation_id)
+
+
+def get_by_customer(db: Session, cno: int) -> list[Reserve]:
+    return db.scalars(select(Reserve).where(Reserve.cno == cno)).all()
+
+
+def remove(db: Session, reservation_id: int) -> Reserve | None:
+    db_obj = db.get(Reserve, reservation_id)
+    if db_obj:
+        db.delete(db_obj)
+        db.commit()
+    return db_obj

--- a/app/models/reservation.py
+++ b/app/models/reservation.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
 from datetime import datetime
-from sqlalchemy import String, DateTime, Integer, Numeric, ForeignKey, ForeignKeyConstraint
+from sqlalchemy import (
+    String,
+    DateTime,
+    Integer,
+    Numeric,
+    ForeignKey,
+    ForeignKeyConstraint,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
 
 class Reserve(Base):
     __tablename__ = "Reserve"
 
-    flightNo: Mapped[str] = mapped_column(String(20), primary_key=True)
-    departureDateTime: Mapped[datetime] = mapped_column(DateTime, primary_key=True)
-    seatClass: Mapped[str] = mapped_column(String(20), primary_key=True)
-    cno: Mapped[int] = mapped_column(ForeignKey("Customer.cno"), primary_key=True)
+    reservationId: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    flightNo: Mapped[str] = mapped_column(String(20))
+    departureDateTime: Mapped[datetime] = mapped_column(DateTime)
+    seatClass: Mapped[str] = mapped_column(String(20))
+    cno: Mapped[int] = mapped_column(ForeignKey("Customer.cno"))
     payment: Mapped[float] = mapped_column(Numeric)
     reserveDateTime: Mapped[datetime] = mapped_column(DateTime)
 
@@ -20,6 +29,7 @@ class Reserve(Base):
             ["flightNo", "departureDateTime", "seatClass"],
             ["Seats.flightNo", "Seats.departureDateTime", "Seats.seatClass"],
         ),
+        UniqueConstraint("flightNo", "departureDateTime", "seatClass", "cno"),
     )
 
     customer: Mapped["Customer"] = relationship("Customer")

--- a/app/schemas/reservation.py
+++ b/app/schemas/reservation.py
@@ -9,6 +9,7 @@ class ReservationCreate(BaseModel):
     payment: float
 
 class ReservationOut(BaseModel):
+    reservationId: int
     flightNo: str
     departureDateTime: datetime
     seatClass: str

--- a/public/mypage.html
+++ b/public/mypage.html
@@ -4,55 +4,57 @@
 <body>
 <nav></nav>
 <main class="container">
-  <h2>나의 예약 정보</h2>
-  <div id="resBox"></div>
-
-  <h2>항공편 상세 정보</h2>
-  <div id="flightBox"></div>
-
-  <div style="margin-top:24px">
-    <button id="btnChange" class="btn-primary">예약 변경</button>
-    <button id="btnCancel" class="btn-danger">예약 취소</button>
-  </div>
+  <h2>나의 예약 목록</h2>
+  <div id="reservations-list"></div>
 </main>
 <footer>ⓒ 2025 C-AIR.</footer>
 
 <script type="module">
-import { renderNav, apiFetch, fmtDateTime, fmtMoney } from "./js/common.js";
+import { renderNav, apiFetch, fmtDateTime } from "./js/common.js";
 renderNav();
 
-const code = new URLSearchParams(location.search).get("code") || "ABC123456789";
-let reservation;  // 전역참조
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const reservations = await apiFetch('/api/profile/me/reservations');
+        const reservationsList = document.getElementById('reservations-list');
+        reservationsList.innerHTML = '';
 
-(async ()=>{
-  try {
-    reservation = await apiFetch(`/api/reservations/${code}`); // ★백엔드 매핑
-    document.getElementById("resBox").innerHTML = `
-      <p><strong>예약 번호:</strong> ${reservation.code}</p>
-      <p><strong>예약 일시:</strong> ${fmtDateTime(reservation.createdAt)}</p>
-      <p><strong>예약자:</strong> ${reservation.customerName} (cno: ${reservation.cno})</p>
-      <p><strong>결제 금액:</strong> ${fmtMoney(reservation.price)}</p>
-      <p><strong>예약 상태:</strong> ${reservation.status}</p>`;
-    const f = reservation.flight;
-    document.getElementById("flightBox").innerHTML = `
-      <p><strong>항공편명:</strong> ${f.flightNo} (${f.airline})</p>
-      <p><strong>출발:</strong> ${f.from} ${fmtDateTime(f.departureTime)}</p>
-      <p><strong>도착:</strong> ${f.to} ${fmtDateTime(f.arrivalTime)}</p>
-      <p><strong>좌석 등급:</strong> ${reservation.seatClass}</p>
-      <p><strong>좌석 가격:</strong> ${fmtMoney(reservation.seatPrice)}</p>`;
-  } catch(err) { alert(err.message); }
-})();
+        if (reservations.length === 0) {
+            reservationsList.innerHTML = '<p>예약 내역이 없습니다.</p>';
+            return;
+        }
 
-document.getElementById("btnCancel").onclick = async ()=>{
-  if (!confirm("정말 예약을 취소하시겠습니까?")) return;
-  try {
-    await apiFetch(`/api/reservations/${code}`, { method:"DELETE" }); // ★
-    alert("취소 완료");
-    location.reload();
-  } catch(err) { alert(err.message); }
-};
+        reservations.forEach(res => {
+            const div = document.createElement('div');
+            div.className = 'reservation-item';
+            div.innerHTML = `
+                <span>항공편: ${res.flightNo}</span>
+                <span>출발: ${fmtDateTime(res.departureDateTime)}</span>
+                <span>좌석: ${res.seatClass}</span>
+                <button class="cancel-btn" data-id="${res.reservationId}">예약 취소</button>
+            `;
+            reservationsList.appendChild(div);
+        });
+    } catch (error) {
+        console.error('Error fetching reservations:', error);
+        alert(error.message);
+    }
+});
 
-document.getElementById("btnChange").onclick = () =>
-  alert("변경 로직은 별도 페이지에서 구현하세요 🙂");
+document.getElementById('reservations-list').addEventListener('click', async (e) => {
+    if (e.target.classList.contains('cancel-btn')) {
+        const reservationId = e.target.dataset.id;
+        if (confirm('정말로 예약을 취소하시겠습니까?')) {
+            try {
+                await apiFetch(`/api/reservations/${reservationId}`, { method: 'DELETE' });
+                alert('예약이 취소되었습니다.');
+                window.location.reload();
+            } catch (error) {
+                console.error('Error canceling reservation:', error);
+                alert(error.message);
+            }
+        }
+    }
+});
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
- add `reservationId` primary key for Reserve model
- adjust CRUD to use new key and expose a customer query
- update reservation endpoints and user profile API
- adapt My Page UI to list reservations and cancel by id

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853f3078598832eb3fb351166e334d7