### PR TITLE
Fix import errors with pydantic v2

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,8 @@
 # 환경 설정값을 관리하는 모듈입니다.
 # app/config.py
 from functools import lru_cache
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 class Settings(BaseSettings):
     oracle_user: str = Field(..., env="ORACLE_USER")

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -11,4 +11,4 @@ class AdminOut(BaseModel):
     username: str
     is_super: bool
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/customer.py
+++ b/app/schemas/customer.py
@@ -13,4 +13,4 @@ class CustomerCreate(CustomerBase):
 class CustomerOut(CustomerBase):
     cno: int
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/flight.py
+++ b/app/schemas/flight.py
@@ -9,7 +9,7 @@ class SeatOut(BaseModel):
     no_of_seats: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class FlightOut(BaseModel):
     airline: str
@@ -21,4 +21,4 @@ class FlightOut(BaseModel):
     seats: List[SeatOut] = []
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/reservation.py
+++ b/app/schemas/reservation.py
@@ -17,4 +17,4 @@ class ReservationOut(BaseModel):
     reserveDateTime: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 passlib[bcrypt]
 python-jose[cryptography] # JWT
 pydantic[email]
+pydantic-settings


### PR DESCRIPTION
## Summary
- adjust config to use `pydantic-settings` BaseSettings
- update schemas to use `from_attributes` instead of deprecated `orm_mode`
- add `pydantic-settings` dependency

## Testing
- `pip install -r requirements.txt`
- `uvicorn app.main:app --reload` *(fails due to missing env vars, but no ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_685411ab1824832eba7a15212afb84b1