### PR TITLE
Switch project to SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | --- | --- |
 | 프론트엔드 | 프레임워크 없이 기본 HTML/CSS/JS와 Fetch API 사용, 필요 시 React로 확장 가능. |
 | 백엔드 | Python 3.10, FastAPI(APIRouter), SQLAlchemy 2 ORM, python-jose 인증. |
-| 데이터베이스 | Oracle 19c(on‑prem 또는 ATP). |
+| 데이터베이스 | SQLite 3 파일 DB. |
 | 개발 도구 | Pip + virtualenv, gunicorn, nginx(프로덕션), GitHub Actions(CI), pre-commit 훅(Black, Ruff). |
 | 테스트 | pytest, pytest-cov, Playwright(e2e). |
 
@@ -81,9 +81,8 @@ data_term/
 
 ## 사전 준비
 
-* **Oracle Instant Client 21.11** 이상을 설치하고 `PATH` / `LD_LIBRARY_PATH`에 추가합니다.
 * **Python 3.10 이상**(3.12 검증 완료).
-* `backend/migrations/versions/0_ddl.sql` 스키마가 적용된 **Oracle DB 19c** 인스턴스가 실행 중이어야 합니다.
+* 로컬에서 SQLite를 사용하므로 별도의 DB 설치가 필요하지 않습니다.
 * 자산을 esbuild로 번들링하려면 Node 18 이상이 필요합니다.
 
 ---
@@ -111,9 +110,7 @@ $ touch .env   # 아래 표를 참고해 값을 입력
 | 변수 | 예시 | 설명 |
 | --- | --- | --- |
 | `APP_ENV` | `development` | 애플리케이션 모드 |
-| `ORACLE_DSN` | `localhost:1521/FREEPDB1` | 전체 DSN 또는 EZConnect 문자열 |
-| `ORACLE_USER` | `CAIR_APP` | 애플리케이션용 DB 사용자 |
-| `ORACLE_PASSWORD` | `secret_pw` | 위 사용자 비밀번호 |
+| `SQLITE_PATH` | `./data.db` | 생성될 SQLite 파일 경로 |
 | `JWT_SECRET` | `example_secret` | 액세스 토큰 서명용 256비트 비밀 값 |
 | `ADMIN_EMAIL` | `admin@c‑air.io` | 기본 관리자 계정 이메일 |
 
@@ -155,11 +152,9 @@ $ npm run dev                  # esbuild-serve 실시간 리로드
 
 | 단계 | 명령 |
 | --- | --- |
-| 새 버전 생성 | `flask db migrate -m "Add loyalty tier"` |
-| DB 적용 | `flask db upgrade` |
-| 롤백 | `flask db downgrade` |
+| 데이터베이스 생성 | `python init_sqlite.py` |
 
-기본 DDL은 `/docs/db‑schema.md`에 있는 스키마와 일치합니다.
+예제 데이터는 `example.sql`을 파싱하여 SQLite로 삽입됩니다.
 
 ---
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,9 +4,7 @@ from pydantic_settings import BaseSettings
 from pydantic import Field
 
 class Settings(BaseSettings):
-    oracle_user: str = Field(..., env="ORACLE_USER")
-    oracle_password: str = Field(..., env="ORACLE_PASSWORD")
-    oracle_dsn: str = Field(..., env="ORACLE_DSN")  # host:port/service_name
+    sqlite_path: str = Field("data.db", env="SQLITE_PATH")
     jwt_secret: str = Field(..., env="JWT_SECRET")
     jwt_alg: str = "HS256"
     app_env: str = Field(..., env="APP_ENV")

--- a/app/database.py
+++ b/app/database.py
@@ -5,12 +5,9 @@ from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from app.config import get_settings
 
 settings = get_settings()
-DB_URI = (
-    f"oracle+oracledb://{settings.oracle_user}:{settings.oracle_password}"
-    f"@{settings.oracle_dsn}?encoding=UTF-8&nencoding=UTF-8"
-)
+DB_URI = f"sqlite:///{settings.sqlite_path}"
 
-engine = create_engine(DB_URI, pool_recycle=3600, echo=False)
+engine = create_engine(DB_URI, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 
 class Base(DeclarativeBase):

--- a/init_sqlite.py
+++ b/init_sqlite.py
@@ -1,0 +1,35 @@
+import re
+from datetime import datetime
+from sqlalchemy import text
+from app.database import engine, Base
+from app.models import admin, customer, flight, reservation
+from pathlib import Path
+
+
+def _convert_timestamp(match: re.Match) -> str:
+    ts = match.group(1)
+    dt = datetime.strptime(ts, "%Y-%m-%d %H-%M-%S")
+    return f"'{dt.strftime('%Y-%m-%d %H:%M:%S')}'"
+
+
+def main():
+    # Recreate all tables defined in SQLAlchemy models
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    sql_path = Path(__file__).parent / "example.sql"
+    if not sql_path.exists():
+        raise FileNotFoundError(sql_path)
+
+    with engine.begin() as conn:
+        content = sql_path.read_text(encoding="utf-8")
+        statements = [s.strip() for s in content.split(';') if s.strip()]
+        for stmt in statements:
+            if not stmt.startswith("INSERT"):
+                continue
+            stmt = re.sub(r"TO_TIMESTAMP\('([^']+)'[^)]*\)", _convert_timestamp, stmt)
+            conn.execute(text(stmt))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn[standard]
 SQLAlchemy>=2.0
-oracledb                  # cx_Oracle 대체, thin-mode 권장
 python-dotenv
 passlib[bcrypt]
 python-jose[cryptography] # JWT


### PR DESCRIPTION
## Summary
- switch configuration to use SQLite instead of Oracle
- update database engine settings
- add `init_sqlite.py` to build the DB from `example.sql`
- update docs for SQLite usage and adjust environment variables
- drop Oracle dependency from requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python init_sqlite.py`
- `sqlite3 data.db '.tables'`

------
https://chatgpt.com/codex/tasks/task_e_685421919194832e8ce77058e076bb62