### PR TITLE
Handle custom backend URL in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ $ gunicorn -k uvicorn.workers.UvicornWorker app.main:app -b 0.0.0.0:8000 --worke
 ### 프론트엔드(정적 서비스)
 
 ```bash
-$ cd frontend
+$ cd public
 $ python -m http.server 3000   # http://localhost:3000/index.html
 ```
+
+> 필요하면 `<script>window.API_BASE_URL="http://localhost:8000";</script>`를
+> HTML 상단에 추가해 백엔드 주소를 조정할 수 있습니다.
 
 esbuild를 사용한다면:
 

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -28,7 +28,8 @@ export async function apiFetch(url, opts = {}) {
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
   // 백엔드 API의 기본 URL을 추가
-  const backendBaseUrl = "http://localhost:8000"; // 또는 http://127.0.0.1:8000
+  // 기본 URL은 window.API_BASE_URL 전역 변수를 사용하고, 없으면 localhost를 사용합니다.
+  const backendBaseUrl = window.API_BASE_URL || "http://localhost:8000"; // 또는 http://127.0.0.1:8000
   const fullUrl = backendBaseUrl + url; // 요청 URL을 백엔드 기본 URL과 결합
 
   const res = await fetch(fullUrl, { ...opts, headers }); // 수정된 부분


### PR DESCRIPTION
## Summary
- allow overriding backend URL by reading `window.API_BASE_URL`
- clarify README about running the static frontend and how to change API URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `APP_ENV=development JWT_SECRET=example ADMIN_EMAIL=admin@c-air.io python init_sqlite.py`

------
https://chatgpt.com/codex/tasks/task_e_6854277e51cc832e965e65db78d55486